### PR TITLE
Fecha completa en cortina de notificaciones

### DIFF
--- a/Spanish/main/MiuiSystemUI.apk/res/values-es/strings.xml
+++ b/Spanish/main/MiuiSystemUI.apk/res/values-es/strings.xml
@@ -169,7 +169,8 @@ Use únicamente el cargador suministrado."</string>
   <string name="settings_toggle_position_divider_page">%1$d conmutadores encima de esta barra están activos</string>
   <string name="settings_toggle_position_reset">Restablecer conmutadores</string>
   <string name="share">Compartir</string>
-  <string name="status_bar_date_format">d.M E</string>
+  <string name="status_bar_date_format">EEEE
+d MMMM yyyy/string>
   <string name="status_bar_date_formatter">%2$s</string>
   <string name="status_bar_network_flow_content">"Hoy: %1$s   Restante: %2$s"</string>
   <string name="status_bar_network_flow_exceed_content">Hoy: %1$s&amp;nbsp;&amp;nbsp;&amp;nbsp;Excedido del plan: &lt;font color=%2$s&gt;%3$s&lt;/font&gt;</string>


### PR DESCRIPTION
Formato adaptado al utilizado en otros idiomas (inglés, francés, italiano...)
Ej:
_dom.
21 febrero 2016_